### PR TITLE
Restore .worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ venv/
 .coverage.*
 .pytest_cache/
 .ruff_cache/
-.worktrees/
 .tox/
 .venv/
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ venv/
 .coverage.*
 .pytest_cache/
 .ruff_cache/
+.worktrees/
 .tox/
 .venv/
 __pycache__/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,36 +1,64 @@
-# Release notes.
+# Release notes
 
-1.0.0 Refresh package documentation for the modern release
-      Drop support for Python 2.7 and old Django releases
-      Modernize packaging and CI with `pyproject.toml`, GitHub Actions, Ruff, pre-commit, Dependabot, and an expanded Python/Django/database test matrix
-      Preserve decimal cursor precision when paginating on `DecimalField` values, including existing page tokens that contain bare JSON numbers
-      Fall back to model `Meta.ordering` when a queryset has no explicit `.order_by(...)`
-      Continue to reject querysets that explicitly clear ordering with `.order_by()`
-      Constrain package metadata to Django `>=4.2,<6.1`
-      Use modern translation imports for compatibility with current Django releases
+## 1.0.0
 
-0.9.9 Gracefully handle a `page=<valid json but invalid key string>`. For instance, this could be `page=2`, which users could enter thinking they are clever.
+- Refresh package documentation for the modern release
+- Drop support for Python 2.7 and old Django releases
+- Modernize packaging and CI with `pyproject.toml`, GitHub Actions, Ruff, pre-commit, Dependabot, and an expanded Python/Django/database test matrix
+- Preserve decimal cursor precision when paginating on `DecimalField` values, including existing page tokens that contain bare JSON numbers
+- Fall back to model `Meta.ordering` when a queryset has no explicit `.order_by(...)`
+- Continue to reject querysets that explicitly clear ordering with `.order_by()`
+- Constrain package metadata to Django `>=4.2,<6.1`
+- Use modern translation imports for compatibility with current Django releases
 
-0.9.8 Correctly handle a `page=1` input that comes from a view. This will be a string, which should be supported since we handle an integer of `1`.
+## 0.9.9
 
-0.9.6 Better handling of empty lists and missing ordering on querysets.
+- Gracefully handle a `page=<valid json but invalid key string>`. For instance, this could be `page=2`, which users could enter thinking they are clever.
 
-0.9.5 Ensure the fixes from both `0.9.4` and `0.9.3` are in the same release.
+## 0.9.8
 
-0.9.4 Support ordering keys that follow lookups. Using these is at your own risk: you must ensure that you are using `.select_related()`, or it will trigger another database fetch for each lookup. This should only apply to the first/last instances; others will not be calculated.
+- Correctly handle a `page=1` input that comes from a view. This will be a string, which should be supported since we handle an integer of `1`.
 
-0.9.3 Fix an issue where we have an empty `object_list`, but still think we have a previous page.
+## 0.9.6
 
-0.9.2 Fix issues with pagination boundaries when there are more than two ordering keys, and objects cross over a boundary that can only be discriminated by the last sort key.
+- Better handling of empty lists and missing ordering on querysets.
 
-0.9.1 Prevent errors when no objects are in the queryset.
+## 0.9.5
 
-0.9.0 Stop supporting page index and total item count.
+- Ensure the fixes from both `0.9.4` and `0.9.3` are in the same release.
 
-0.8.5 Don't fail to render on an empty result set.
+## 0.9.4
 
-0.8.4 Allow installing in Python 2.
+- Support ordering keys that follow lookups. Using these is at your own risk: you must ensure that you are using `.select_related()`, or it will trigger another database fetch for each lookup. This should only apply to the first/last instances; others will not be calculated.
 
-0.8.1 Add description to the PyPI page.
+## 0.9.3
 
-0.8.0 First release.
+- Fix an issue where we have an empty `object_list`, but still think we have a previous page.
+
+## 0.9.2
+
+- Fix issues with pagination boundaries when there are more than two ordering keys, and objects cross over a boundary that can only be discriminated by the last sort key.
+
+## 0.9.1
+
+- Prevent errors when no objects are in the queryset.
+
+## 0.9.0
+
+- Stop supporting page index and total item count.
+
+## 0.8.5
+
+- Don't fail to render on an empty result set.
+
+## 0.8.4
+
+- Allow installing in Python 2.
+
+## 0.8.1
+
+- Add description to the PyPI page.
+
+## 0.8.0
+
+- First release.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,29 +1,36 @@
 # Release notes.
 
-* Unreleased: Drop support for Python 2.7. Modernize packaging and CI for GitHub with `pyproject.toml`, GitHub Actions, Ruff, pre-commit, Dependabot, and an expanded Python/Django/database test matrix. Preserve decimal cursor precision when paginating on `DecimalField` values, including existing page tokens that contain bare JSON numbers. Also allow `KeysetPaginator` to fall back to model `Meta.ordering` when a queryset has no explicit `order_by()`, while still rejecting querysets that explicitly clear ordering. Constrain package metadata to the tested Django range (`>=4.2,<6.1`) and use modern translation imports for compatibility with current Django releases.
+1.0.0 Refresh package documentation for the modern release
+      Drop support for Python 2.7 and old Django releases
+      Modernize packaging and CI with `pyproject.toml`, GitHub Actions, Ruff, pre-commit, Dependabot, and an expanded Python/Django/database test matrix
+      Preserve decimal cursor precision when paginating on `DecimalField` values, including existing page tokens that contain bare JSON numbers
+      Fall back to model `Meta.ordering` when a queryset has no explicit `.order_by(...)`
+      Continue to reject querysets that explicitly clear ordering with `.order_by()`
+      Constrain package metadata to Django `>=4.2,<6.1`
+      Use modern translation imports for compatibility with current Django releases
 
-* 0.9.9: Gracefully handle a `page=<valid json but invalid key string>`. For instance, this could be `page=2`, which users could enter thinking they are clever.
+0.9.9 Gracefully handle a `page=<valid json but invalid key string>`. For instance, this could be `page=2`, which users could enter thinking they are clever.
 
-* 0.9.8: Correctly handle a page=1 input that comes from a view. This will be a string, which should be supported since we handle an integer of 1.
+0.9.8 Correctly handle a `page=1` input that comes from a view. This will be a string, which should be supported since we handle an integer of `1`.
 
-* 0.9.6: Better handling of empty lists and missing ordering on querysets.
+0.9.6 Better handling of empty lists and missing ordering on querysets.
 
-* 0.9.5: Ensure the fixes from both 0.9.4 and 0.9.3 are in the same release.
+0.9.5 Ensure the fixes from both `0.9.4` and `0.9.3` are in the same release.
 
-* 0.9.4: Support ordering keys that follow lookups. Using these is at your own risk: You must ensure that you are using .select_related(), or it will trigger another database fetch for each lookup. This should only apply to the first/last instances, others will not be calculated.
+0.9.4 Support ordering keys that follow lookups. Using these is at your own risk: you must ensure that you are using `.select_related()`, or it will trigger another database fetch for each lookup. This should only apply to the first/last instances; others will not be calculated.
 
-* 0.9.3: Fix an issue where we have an empty object_list, but still think we have a previous page.
+0.9.3 Fix an issue where we have an empty `object_list`, but still think we have a previous page.
 
-* 0.9.2: Fix issues with pagination boundaries when there are more than two ordering keys, and objects cross over a boundary that can only be discriminated by the last sort key.
+0.9.2 Fix issues with pagination boundaries when there are more than two ordering keys, and objects cross over a boundary that can only be discriminated by the last sort key.
 
-* 0.9.1: Prevent errors when no objects in queryset.
+0.9.1 Prevent errors when no objects are in the queryset.
 
-* 0.9.0: Stop supporting page index and total item count.
+0.9.0 Stop supporting page index and total item count.
 
-* 0.8.5: Don't fail to render on empty result set.
+0.8.5 Don't fail to render on an empty result set.
 
-* 0.8.4: Allow installing in Python 2.
+0.8.4 Allow installing in Python 2.
 
-* 0.8.1: Add description to pypi page.
+0.8.1 Add description to the PyPI page.
 
-* 0.8.0: First release.
+0.8.0 First release.

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ If your queryset does not call `.order_by(...)`, the paginator will also honor t
 
 ```python
 class Event(models.Model):
-    label = models.TextField()
-    sequence = models.IntegerField()
+    timestamp = models.DateTimeField()
+    group = models.TextField()
 
     class Meta:
-        ordering = ("label", "sequence")
+        ordering = ("-timestamp", "group", "pk")
 
 
 paginator = KeysetPaginator(Event.objects.all(), 10)

--- a/README.md
+++ b/README.md
@@ -1,68 +1,105 @@
-# Keyset Pagination for Django.
+# Keyset Pagination for Django
 
 [![CI](https://github.com/schinckel/django-keyset-pagination/actions/workflows/ci.yml/badge.svg)](https://github.com/schinckel/django-keyset-pagination/actions/workflows/ci.yml)
 
-Django pagination uses the LIMIT/OFFSET method. This is fine for smaller offsets, but once you start getting beyond a few pages, it can perform really badly. This is because the database needs to fetch all of the previous rows, even though it discards them.
+Django's built-in pagination uses `LIMIT/OFFSET`. That works well for small offsets, but it gets progressively more expensive as the offset grows because the database still has to walk past the earlier rows.
 
-Using Keyset Pagination allows for better performing "next page" fetches, at the cost of not being able to randomly fetch a page. That is, if you know the last element from page N-1, then you may fetch page N, but otherwise you really can't.
+This package implements keyset pagination, also called the seek method. Instead of asking for "page 200", the client asks for "the next page after this row" or "the previous page before this row". That keeps pagination efficient for large result sets, but it also means random page access and page-number iteration are not supported.
 
-Keyset Pagination, sometimes called the Seek Method, has been documented by [Markus Winand](https://use-the-index-luke.com/sql/partial-results/fetch-next-page) and [Joe Nelson](https://www.citusdata.com/blog/2016/03/30/five-ways-to-paginate/). If you are not familiar with the concept, I strongly suggest you read the articles above.
+If you are new to the approach, the background articles from [Markus Winand](https://use-the-index-luke.com/sql/partial-results/fetch-next-page) and [Joe Nelson](https://www.citusdata.com/blog/2016/03/30/five-ways-to-paginate/) are worth reading.
 
-In order to use the paginator within this package, you will probably also need to use the provided View mixin: this changes the way a queryset is paginated to enable non-integer "page numbers".
+## Installation
 
-    class List(PaginationMixin, ListView):
-        paginator_class = KeysetPaginator
-        paginate_by = 10
-        queryset = MyModel.objects.order_by('-timestamp', 'group')
+Install the published package:
 
-You won't be able to iterate through page numbers in a template in the same way: you are limited to next and previous pages. Otherwise, you construct them in largely the same way:
+```bash
+python -m pip install django-keyset-pagination-plus
+```
 
-    <a href="{% url 'mymodel:list' %}?page={{ page_obj.previous_page_number }}">
-      Prev Page
-    </a>
+The import path remains `keyset_pagination`.
 
-    <a href="{% url 'mymodel:list' %}?page={{ page_obj.next_page_number }}">
-      Next Page
-    </a>
+## Usage
 
-Page tokens are JSON payloads built from the ordering columns in your queryset. They are opaque from the caller's perspective and should be passed back unchanged. Ordering by `DecimalField` values is supported, and decimal cursor values are preserved without being coerced through binary floats.
+In most class-based views you will want both the paginator and the included mixin, because Django's default pagination flow assumes integer page numbers.
 
-If your queryset does not call `.order_by(...)`, the paginator will also honor the model's `Meta.ordering`. This allows views that rely on a model's default ordering to paginate without repeating the same ordering in every queryset:
+```python
+from django.views.generic import ListView
 
-    class Event(models.Model):
-        label = models.TextField()
-        sequence = models.IntegerField()
+from keyset_pagination.mixin import PaginateMixin
+from keyset_pagination.paginator import KeysetPaginator
 
-        class Meta:
-            ordering = ("label", "sequence")
 
-    paginator = KeysetPaginator(Event.objects.all(), 10)
+class EventList(PaginateMixin, ListView):
+    paginator_class = KeysetPaginator
+    paginate_by = 10
+    queryset = Event.objects.order_by("-timestamp", "group", "pk")
+```
 
-If you explicitly clear ordering with `.order_by()`, the paginator still raises `ValueError`, because keyset pagination requires a deterministic ordering definition.
+If your queryset does not call `.order_by(...)`, the paginator will also honor the model's `Meta.ordering`. That lets you rely on a model's default ordering without repeating it in every view:
 
-Note that you do not get access to the length of the queryset, nor the number of pages, because these could be expensive queries. You really don't need to know that ;)
+```python
+class Event(models.Model):
+    label = models.TextField()
+    sequence = models.IntegerField()
 
-However, I like to use GET forms to [enable pagination of filtered results](https://schinckel.net/2014/08/17/leveraging-html-and-django-forms%3A-pagination-of-filtered-results/):
+    class Meta:
+        ordering = ("label", "sequence")
 
-    <button form="target-form"
-            name="page"
-            value="{{ page_obj.previous_page_number }}"
-            type="submit">
-      &larr; Prev Page
-    </button>
 
-    <button form="target-form"
-            name="page"
-            value="{{ page_obj.next_page_number }}"
-            type="submit">
-      Next Page &rarr;
-    <button>
+paginator = KeysetPaginator(Event.objects.all(), 10)
+```
 
+A few important constraints:
+
+- The queryset must have a deterministic ordering. If you do not provide `.order_by(...)`, the paginator falls back to the model's `Meta.ordering`.
+- If you explicitly clear ordering with `.order_by()`, the paginator raises `ValueError`.
+- Use a stable ordering. In practice that usually means appending a unique tiebreaker such as `pk`.
+- Ordering across related fields such as `location__name` is supported, but you should usually pair that with `select_related()` to avoid extra queries when page tokens are generated.
+- Only next/previous navigation is available. `count`, `num_pages`, and page-number iteration are intentionally unavailable.
+
+## Template usage
+
+Cursor values are opaque JSON tokens built from the queryset ordering columns. Treat them as implementation details and pass them back unchanged.
+
+```django
+{% if page_obj.has_previous %}
+  <a href="?page={{ page_obj.previous_page_number }}">Previous page</a>
+{% endif %}
+
+{% if page_obj.has_next %}
+  <a href="?page={{ page_obj.next_page_number }}">Next page</a>
+{% endif %}
+```
+
+The same approach works well with `GET` forms when the list also has filters:
+
+```django
+{% if page_obj.has_previous %}
+  <button form="target-form"
+          name="page"
+          value="{{ page_obj.previous_page_number }}"
+          type="submit">
+    &larr; Previous page
+  </button>
+{% endif %}
+
+{% if page_obj.has_next %}
+  <button form="target-form"
+          name="page"
+          value="{{ page_obj.next_page_number }}"
+          type="submit">
+    Next page &rarr;
+  </button>
+{% endif %}
+```
+
+Cursor serialization handles values that do not round-trip cleanly through plain JSON types, including `Decimal`, `datetime`, `date`, `time`, and PostgreSQL range values. Decimal cursor values are parsed with `Decimal`, so precision is preserved even when the incoming token contains a bare JSON number.
 
 ## Supported versions
 
 The package supports Python 3.10+ and Django `>=4.2,<6.1`.
-It is tested against modern Django and Python releases via GitHub Actions, with a current matrix covering Django 4.2, 5.2, and 6.0 on SQLite and additional integration coverage for PostgreSQL and MySQL.
+
+Continuous integration currently exercises Django 4.2, 5.2, and 6.0 on SQLite, plus PostgreSQL and MySQL integration environments for those Django releases.
 
 ## Development
 
@@ -73,8 +110,15 @@ tox -e py312-django52-sqlite
 tox -p auto
 ```
 
-The repository includes GitHub Actions workflows for CI and release publishing, Dependabot updates, Ruff linting/formatting, and tox-driven test environments for SQLite and PostgreSQL. For a full local run, use `tox -p auto` or `make test-all` to execute the tox matrix in parallel.
+Helpful shortcuts are also available through `make`:
 
-For local MySQL runs on macOS with Homebrew, install `mysql-client` and `pkgconf`. The MySQL tox environments default `MYSQLCLIENT_CFLAGS` and `MYSQLCLIENT_LDFLAGS` to the Homebrew `mysql-client` paths, and you can override them with environment variables if your local setup differs.
+```bash
+make lint
+make test
+make test-all
+make package
+```
 
-See https://schinckel.net/2018/11/23/keyset-pagination-in-django/ for more details about how this package works.
+For local MySQL runs on macOS with Homebrew, install `mysql-client` and `pkgconf`. The MySQL tox environments default `MYSQLCLIENT_CFLAGS` and `MYSQLCLIENT_LDFLAGS` to Homebrew's `mysql-client` paths, and you can override them with environment variables if your local setup differs.
+
+See [schinckel.net: Keyset Pagination in Django](https://schinckel.net/2018/11/23/keyset-pagination-in-django/) for a longer walkthrough of the approach.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-keyset-pagination-plus"
-version = "0.10.0"
+version = "1.0.0"
 description = "Keyset pagination (seek method) for Django."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keyset_pagination/__init__.py
+++ b/src/keyset_pagination/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.10.0"
+__version__ = "1.0.0"


### PR DESCRIPTION
Reverts the removal of `.worktrees/` from `.gitignore` that was incorrectly dropped in the 1.0.0 release prep commit.

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.